### PR TITLE
inline sub2ind in statistics function for BayesScore

### DIFF
--- a/src/learning.jl
+++ b/src/learning.jl
@@ -60,7 +60,13 @@ function statistics!(N::Vector{Any}, b::BayesNet, d::Matrix{Int})
             j = 1
             p = parentList[i]
             if !isempty(p)
-                j = sub2ind(r[p], d[p,di]...)
+                ndims = length(r[p])
+                j = int(d[p,di][1])
+                stride = 1
+                for kk=2:ndims
+                    stride = stride * r[p][kk-1]
+                    j += (int(d[p,di][kk])-1) * stride
+                end
             end
             N[i][k,j] += 1.
         end


### PR DESCRIPTION
Much to my surprise, in profiling an extremely naive local search based structure learning program, I found that `j = sub2ind(r[p], d[p,di]...)` [here](https://github.com/sisl/BayesNets.jl/blob/master/src/learning.jl#L63) was on the critical path. Apparently the tuple expansion isn't as cheap as you might hope. On a whim I inlined the general form of `sub2ind` from [base](https://github.com/JuliaLang/julia/blob/master/base/abstractarray.jl#L998-L1007) and got a good 5-15% speedup, consistent across several tests on several machines. You may wish to include this change in the main branch (or find a better way of accomplishing the same effect).
