### PR TITLE
RFC: first cut at LightGraphs implementation

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.3-
-Graphs
+LightGraphs
 DataFrames
 TikzGraphs
 LightXML

--- a/src/learning.jl
+++ b/src/learning.jl
@@ -38,7 +38,7 @@ end
 function statistics(b::BayesNet, alpha = 0.)
     n = length(b.names)
     r = [length(domain(b, node).elements) for node in b.names]
-    parentList = [int(collect(in_neighbors(i, b.dag))) for i = 1:n]
+    parentList = [int(collect(in_neighbors(b.dag, i))) for i = 1:n]
     N = cell(n)
     for i = 1:n
         q = 1
@@ -53,7 +53,7 @@ end
 function statistics!(N::Vector{Any}, b::BayesNet, d::Matrix{Int})
     r = [length(domain(b, node).elements) for node in b.names]
     (n, m) = size(d)
-    parentList = [int(collect(in_neighbors(i, b.dag))) for i = 1:n]
+    parentList = [int(collect(in_neighbors(b.dag, i))) for i = 1:n]
     for i = 1:n
         p = parentList[i]
         if !isempty(p)
@@ -62,7 +62,7 @@ function statistics!(N::Vector{Any}, b::BayesNet, d::Matrix{Int})
             for k = 2:Np
                 stridevec[k] = stridevec[k-1] * r[p[k-1]]
             end
-            js = d[p,:]' * stridevec - sum(stridevec) + 1 
+            js = d[p,:]' * stridevec - sum(stridevec) + 1
             # side note: flipping d to make array access column-major improves speed by a further 10%
             # this change could be hacked into this method (dT = d'), but should really be made in indexData
         else


### PR DESCRIPTION
Hi,

I wanted to see whether LightGraphs provided more performance for BayesNets, so I took the liberty of 1) fixing BayesNets to work on 0.4 (`Range1` is no longer valid), and 2) reimplementing the DAGs as `LightGraphs.DiGraph` instead of `simple_graph`. The good news is that things like edge removal are built into LightGraphs; this makes several functions much simpler. There's probably a good deal more optimization we could do but I wanted to gauge interest before spending a whole lot more time on this. Please let me know.

PS: things like plotting might not work yet due to the dependency on TikzGraphs and the fact that TikzGraphs doesn't grok LightGraphs yet. That can certainly be fixed.
