### PR TITLE
tightening things up a bit

### DIFF
--- a/src/BayesNets.jl
+++ b/src/BayesNets.jl
@@ -101,7 +101,7 @@ end
 
 function removeEdges!(bn::BayesNet, pairs)
   for p in pairs
-      rem_edge!(bn.dag, bn.index[p[1]], bn.index[p[2]])
+      removeEdge!(bn, p[1], p[2])
   end
   bn
 end

--- a/src/learning.jl
+++ b/src/learning.jl
@@ -38,7 +38,7 @@ end
 function statistics(b::BayesNet, alpha = 0.)
     n = length(b.names)
     r = [length(domain(b, node).elements) for node in b.names]
-    parentList = [int(collect(in_neighbors(b.dag, i))) for i = 1:n]
+    parentList = [collect(in_neighbors(b.dag, i)) for i = 1:n]
     N = cell(n)
     for i = 1:n
         q = 1
@@ -53,7 +53,7 @@ end
 function statistics!(N::Vector{Any}, b::BayesNet, d::Matrix{Int})
     r = [length(domain(b, node).elements) for node in b.names]
     (n, m) = size(d)
-    parentList = [int(collect(in_neighbors(b.dag, i))) for i = 1:n]
+    parentList = [collect(in_neighbors(b.dag, i)) for i = 1:n]
     for i = 1:n
         p = parentList[i]
         if !isempty(p)


### PR DESCRIPTION
I think this is the extent of optimizations at this point... the code for `RemoveEdge[s]!()` is now consistent with `AddEdge[s]!()`, and I got rid of the `int` casting for neighbors since it's no longer needed (and throws deprecation warnings in any case).