### PR TITLE
Import has_edge from LightGraphs

### DIFF
--- a/src/BayesNets.jl
+++ b/src/BayesNets.jl
@@ -3,7 +3,7 @@ module BayesNets
 export BayesNet, addEdge!, removeEdge!, addEdges!, removeEdges!, CPD, CPDs, prob, setCPD!, pdf, rand, randBernoulliDict, randDiscreteDict, table, domain, Assignment, *, sumout, normalize, select, randTable, NodeName, consistent, estimate, randTableWeighted, estimateConvergence, isValid, hasEdge
 export Domain, BinaryDomain, DiscreteDomain, RealDomain, domain, cpd, parents, setDomain!, plot
 
-import LightGraphs: DiGraph, Edge, rem_edge!, add_edge!, topological_sort_by_dfs, in_edges, src, dst, in_neighbors, is_cyclic
+import LightGraphs: DiGraph, Edge, rem_edge!, add_edge!, has_edge, topological_sort_by_dfs, in_edges, src, dst, in_neighbors, is_cyclic
 import TikzGraphs: plot
 import Base: rand, select, *
 import DataFrames: DataFrame, groupby, array, isna


### PR DESCRIPTION
Defined function hasEdge depends on LightGraphs's has_edge function, which should be explicitly imported for this module. For reasons I don't well understand, this was not necessary on my Arch Linux machine (Julia installed via package manager), but was necessary on my Mac OS X 10.10.2 machine (Julia installed via Mac package), even though both were running Julia v0.3.11, and both successfully completed Pkg.add("BayesNets"), Pkg.add("LightGraphs"), using BayesNets, using LightGraphs, etc.