### PR TITLE
Improved bayesian_score_component performance when using a uniform prior

### DIFF
--- a/src/BayesNets.jl
+++ b/src/BayesNets.jl
@@ -54,6 +54,7 @@ export
     GraphSearchStrategy,
     K2GraphSearch,
     GreedyHillClimbing,
+    ScanGreedyHillClimbing,
 
     statistics,
     index_data,
@@ -73,5 +74,6 @@ include("DiscreteBayesNet/dirichlet_priors.jl")
 include("DiscreteBayesNet/discrete_bayes_net.jl")
 include("DiscreteBayesNet/structure_scoring.jl")
 include("DiscreteBayesNet/greedy_hill_climbing.jl")
+include("DiscreteBayesNet/scan_greedy_hill_climbing.jl")
 
 end # module

--- a/src/DiscreteBayesNet/scan_greedy_hill_climbing.jl
+++ b/src/DiscreteBayesNet/scan_greedy_hill_climbing.jl
@@ -1,0 +1,146 @@
+type ScanGreedyHillClimbing <: GraphSearchStrategy
+    cache::ScoreComponentCache
+    max_n_parents::Int
+    max_depth::Int
+    prior::DirichletPrior
+
+    function ScanGreedyHillClimbing(
+        cache::ScoreComponentCache;
+        max_n_parents::Int=3,
+        max_depth::Int=1,
+        prior::DirichletPrior=UniformPrior(1.0),
+        )
+
+        new(cache, max_n_parents, max_depth, prior)
+    end
+end
+
+function greedyScore(score_components, n, prior_parent_list, datamat, params::ScanGreedyHillClimbing, ncategories::Vector{Int})  
+    parent_list = prior_parent_list
+    while true
+
+        # Compute score
+        best_diff = 0.0
+        best_parent_list = parent_list
+        for i in 1:n
+            
+            # 1) add an edge (j->i)
+            if length(parent_list[i]) < params.max_n_parents
+                for j in deleteat!(collect(1:n), parent_list[i])
+                    if adding_edge_preserves_acyclicity(parent_list, j, i)
+                        new_parents = sort!(push!(copy(parent_list[i]), j))
+                        #println("A")
+                        new_component_score = bayesian_score_component(i, new_parents, ncategories, datamat, params.prior, params.cache)
+                        #println("B")
+                        if new_component_score - score_components[i] > best_diff
+                            best_diff = new_component_score - score_components[i]
+                            best_parent_list = deepcopy(parent_list)
+                            best_parent_list[i] = new_parents
+                        end
+                    end
+                end
+            end
+
+            # 2) remove an edge
+            for (idx, j) in enumerate(parent_list[i])
+
+                new_parents = deleteat!(copy(parent_list[i]), idx)
+                new_component_score = bayesian_score_component(i, new_parents, ncategories, datamat, params.prior, params.cache)
+                if new_component_score - score_components[i] > best_diff
+                    best_diff = new_component_score - score_components[i]
+                    best_parent_list = deepcopy(parent_list)
+                    best_parent_list[i] = new_parents
+                end
+
+
+                # 3) flip an edge
+                if length(parent_list[j]) < params.max_n_parents
+                    deleteat!(parent_list[i], idx)
+                    if adding_edge_preserves_acyclicity(parent_list, i, j)
+                        sort!(push!(parent_list[j], i))
+                        new_diff = bayesian_score_component(i, copy(parent_list[i]), ncategories, datamat, params.prior, params.cache) - score_components[i]
+                        new_diff += bayesian_score_component(j, copy(parent_list[j]), ncategories, datamat, params.prior, params.cache) - score_components[j]
+                        if new_diff > best_diff
+                            best_diff = new_diff
+                            best_parent_list = deepcopy(parent_list)
+                        end
+                        deleteat!(parent_list[j], findin(parent_list[j], i))
+                    end
+                    sort!(push!(parent_list[i], j))
+                 end
+            end
+        end
+
+        if best_diff > 0.0
+            parent_list = best_parent_list
+            score_components = bayesian_score_components(parent_list, ncategories, datamat, params.prior, params.cache)
+        else
+            break
+        end
+    end
+    sum(score_components), parent_list
+end
+
+function Distributions.fit(::Type{DiscreteBayesNet}, data::DataFrame, params::ScanGreedyHillClimbing;
+    ncategories::Vector{Int} = map!(i->infer_number_of_instantiations(data[i]), Array(Int, ncol(data)), 1:ncol(data)),
+    )
+ 
+    n = ncol(data)
+    parent_list = map!(i->Int[], Array(Vector{Int}, n), 1:n)
+    datamat = convert(Matrix{Int}, data)'
+    score_components = bayesian_score_components(parent_list, ncategories, datamat, params.prior, params.cache)
+    
+    # 0 depth
+    depth = 0
+    best, out_score = greedyScore(score_components, n, parent_list, datamat, params, ncategories)
+
+    # > 1 depth
+    greedy_parents = out_score
+    while depth < params.max_depth 
+        depth += 1
+
+        # Scan parameters
+        best_parent_list = parent_list
+        complete = true
+        for i in 1:n
+
+            # 1) add an edge (j->i)
+            for j in deleteat!(collect(1:n), parent_list[i])
+                if adding_edge_preserves_acyclicity(parent_list, j, i)
+                    if length(parent_list[i]) < params.max_n_parents
+                        new_parent_list = copy(parent_list)
+                        new_parents = sort!(push!(new_parent_list[i], j))
+                        new_score, out_score = greedyScore(score_components, n, new_parent_list, datamat, params, ncategories)
+                        if new_score > best
+                            best = new_score
+                            complete = false
+                            best_parent_list = new_parent_list
+                            greedy_parents = out_score
+                        end
+                    end
+                end
+            end
+        
+            # 2) did this improve our greedy score?
+            # Add the best edge and continue
+            parent_list = best_parent_list
+        end
+        if complete 
+            break
+        end
+    end
+
+    # compute the greedy solution
+    parent_list = greedy_parents
+    println("Scan solution score: ", best)
+
+    # construct the BayesNet
+    cpds = Array(DiscreteCPD, n)
+    varnames = names(data)
+    for i in 1:n
+        name = varnames[i]
+        parents = varnames[parent_list[i]]
+        cpds[i] = fit(DiscreteCPD, data, name, parents, params.prior, parental_ncategories=ncategories[parent_list[i]], target_ncategories=ncategories[i])
+    end
+    BayesNet(cpds)
+end

--- a/src/DiscreteBayesNet/structure_scoring.jl
+++ b/src/DiscreteBayesNet/structure_scoring.jl
@@ -82,7 +82,7 @@ function bayesian_score_component{I<:Integer}(
     )
 
     if typeof(prior) == UniformPrior
-        #return bayesian_score_component_uniform(i, parents, ncategories, data, prior)
+        return bayesian_score_component_uniform(i, parents, ncategories, data, prior)
     end
     alpha = get(prior, i, ncategories, parents)
     bayesian_score_component(i, parents, ncategories, data, alpha)

--- a/src/DiscreteBayesNet/structure_scoring.jl
+++ b/src/DiscreteBayesNet/structure_scoring.jl
@@ -37,6 +37,42 @@ function bayesian_score_component{I<:Integer}(
     N = sparse(vec(data[i,:]), vec(js), 1, size(alpha)...) # note: duplicates are added together
     sum(lgamma(alpha + N)) - sum(lgamma(alpha)) + sum(lgamma(sum(alpha,1))) - sum(lgamma(sum(alpha,1) + sum(N,1)))::Float64
 end
+function bayesian_score_component_uniform{I<:Integer}(
+    i::Int,
+    parents::AbstractVector{I},
+    ncategories::AbstractVector{Int},
+    data::AbstractMatrix{Int},
+    prior::DirichletPrior,
+    )
+
+    (n, m) = size(data)
+    if !isempty(parents)
+        Np = length(parents)
+        stridevec = fill(1, Np)
+        for k in 2:Np
+            stridevec[k] = stridevec[k-1] * ncategories[parents[k-1]]
+        end
+        js = (data[parents,:] - 1)' * stridevec + 1
+    else
+        js = fill(1, m)
+    end
+
+    n = prod(ncategories[parents])
+    N = sparse(data[i,:], js, 1, ncategories[i], n...) # note: duplicates are added together
+
+    u = prior.α
+    p = lgamma(u)
+
+    # Given a sparse N, we can be clever in our calculation and not waste time 
+    # computing the same lgamma values by exploiting the sparse structure. 
+    sum0 = sum(lgamma(nonzeros(N) + u)) + p * (ncategories[i] * n - nnz(N))
+    sum1 = n * ncategories[i] * p
+    sum2 = n * lgamma(ncategories[i] * u)
+    cc = ncategories[i] * u
+    sN = sum(N[i,:] for i=1:ncategories[i])
+    sum3 = sum(lgamma(nonzeros(sN) + cc)) + (size(N, 2) - nnz(sN)) * lgamma(cc)
+    sum0 - sum1 + sum2 - sum3::Float64
+end
 function bayesian_score_component{I<:Integer}(
     i::Int,
     parents::AbstractVector{I},
@@ -45,6 +81,9 @@ function bayesian_score_component{I<:Integer}(
     prior::DirichletPrior,
     )
 
+    if typeof(prior) == UniformPrior
+        #return bayesian_score_component_uniform(i, parents, ncategories, data, prior)
+    end
     alpha = get(prior, i, ncategories, parents)
     bayesian_score_component(i, parents, ncategories, data, alpha)
 end

--- a/src/DiscreteBayesNet/structure_scoring.jl
+++ b/src/DiscreteBayesNet/structure_scoring.jl
@@ -69,7 +69,12 @@ function bayesian_score_component_uniform{I<:Integer}(
     sum1 = n * ncategories[i] * p
     sum2 = n * lgamma(ncategories[i] * u)
     cc = ncategories[i] * u
-    sN = sum(N[i,:] for i=1:ncategories[i])
+
+    @static if Base.VERSION.major == 0 && Base.VERSION.minor < 5 
+        sN = sparsevec(sum(N[1:ncategories[i],:], 1)) # Slower, but should be supported by Julia 0.4
+    else 
+        sN = sum(N[i,:] for i=1:ncategories[i])
+    end
     sum3 = sum(lgamma(nonzeros(sN) + cc)) + (size(N, 2) - nnz(sN)) * lgamma(cc)
     sum0 - sum1 + sum2 - sum3::Float64
 end

--- a/test/test_discrete_bayes_nets.jl
+++ b/test/test_discrete_bayes_nets.jl
@@ -88,3 +88,24 @@ let
 	@test isapprox(pdf(get(bn, :a), :a=>1, :b=>1, :c=>2), 0.5, atol=1e-4)
 	@test isapprox(pdf(get(bn, :a), :a=>1, :b=>2, :c=>2), 0.7, atol=1e-4)
 end
+
+let
+	data = DataFrame(a=[1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,   2,2,2,2,2,2,2,2, 2,2,2,2,2,2,2,2],
+		             b=[1,1,1,1,1,1,1,1, 2,2,2,2,2,2,2,2,   1,1,1,1,2,2,2,2, 2,2,2,2,2,2,2,2],
+		             c=[1,1,1,1,1,1,2,2, 2,2,2,2,2,2,1,1,   1,1,2,2,1,1,2,2, 1,1,1,1,1,1,1,1])
+
+	cache = ScoreComponentCache(data)
+	params = ScanGreedyHillClimbing(cache, max_n_parents=3, max_depth=1, prior=UniformPrior(2.0))
+	@test params.max_n_parents == 3
+	@test params.prior == UniformPrior(2.0)
+
+	params = ScanGreedyHillClimbing(cache)
+	bn = fit(DiscreteBayesNet, data, params)
+	@test length(bn) == ncol(data)
+	@test isapprox(pdf(get(bn, :c), :c=>1), 0.61765, atol=1e-4)
+	@test isapprox(pdf(get(bn, :b), :b=>1), 0.38235, atol=1e-4)
+	@test isapprox(pdf(get(bn, :a), :a=>1, :b=>1, :c=>1), 0.7, atol=1e-4)
+	@test isapprox(pdf(get(bn, :a), :a=>1, :b=>2, :c=>1), 0.21428, atol=1e-4)
+	@test isapprox(pdf(get(bn, :a), :a=>1, :b=>1, :c=>2), 0.5, atol=1e-4)
+	@test isapprox(pdf(get(bn, :a), :a=>1, :b=>2, :c=>2), 0.7, atol=1e-4)
+end


### PR DESCRIPTION
As part of my final project for CS238 (2016) I have created a new discrete structure learning algorithm. I also improved the bayesian_score_component performance when using a uniform prior to a point where it is practical to use the BayesNet framework for assignment scoring. 