### PR TITLE
add missing ::Factor constraint on Base.rand! method extension

### DIFF
--- a/src/Factors/factors_main.jl
+++ b/src/Factors/factors_main.jl
@@ -135,7 +135,7 @@ Base.indexin(dims::NodeNames, ϕ::Factor) = indexin(dims, names(ϕ))
 
 Fill with random values
 """
-Base.rand!(ϕ) = rand!(ϕ.potential)
+Base.rand!(ϕ::Factor) = rand!(ϕ.potential)
 
 """
 Appends a new dimension to a Factor


### PR DESCRIPTION
I'm assuming this was meant to be for the Factor type, since ::Any won't usually
have a `.potential` field