### PR TITLE
Fix Julia 1.0 tests

### DIFF
--- a/doc/BayesNets.ipynb
+++ b/doc/BayesNets.ipynb
@@ -651,7 +651,7 @@
        "\n"
       ],
       "text/plain": [
-       "BayesNets.BayesNet{BayesNets.CPDs.CPD}({3, 2} directed simple Int64 graph, BayesNets.CPDs.CPD[BayesNets.CPDs.StaticCPD{Distributions.Categorical{Float64}}(:a, Symbol[], Distributions.Categorical{Float64}(K=2, p=[0.3, 0.7])), BayesNets.CPDs.StaticCPD{Distributions.Categorical{Float64}}(:b, Symbol[], Distributions.Categorical{Float64}(K=2, p=[0.6, 0.4])), BayesNets.CPDs.CategoricalCPD{Distributions.Bernoulli}(:c, Symbol[:a, :b], [2, 2], Distributions.Bernoulli[Distributions.Bernoulli{Float64}(p=0.1), Distributions.Bernoulli{Float64}(p=0.2), Distributions.Bernoulli{Float64}(p=1.0), Distributions.Bernoulli{Float64}(p=0.4)])], Dict(:a=>1,:b=>2,:c=>3))"
+       "BayesNets.BayesNet{BayesNets.CPDs.CPD}({3, 2} directed simple Int64 graph, BayesNets.CPDs.CPD[BayesNets.CPDs.StaticCPD{Distributions.Categorical{Float64,Vector{Float64}}}(:a, Symbol[], Distributions.Categorical{Float64,Vector{Float64}}(K=2, p=[0.3, 0.7])), BayesNets.CPDs.StaticCPD{Distributions.Categorical{Float64,Vector{Float64}}}(:b, Symbol[], Distributions.Categorical{Float64,Vector{Float64}}(K=2, p=[0.6, 0.4])), BayesNets.CPDs.CategoricalCPD{Distributions.Bernoulli}(:c, Symbol[:a, :b], [2, 2], Distributions.Bernoulli[Distributions.Bernoulli{Float64}(p=0.1), Distributions.Bernoulli{Float64}(p=0.2), Distributions.Bernoulli{Float64}(p=1.0), Distributions.Bernoulli{Float64}(p=0.4)])], Dict(:a=>1,:b=>2,:c=>3))"
       ]
      },
      "execution_count": 13,
@@ -941,7 +941,7 @@
        "\n"
       ],
       "text/plain": [
-       "BayesNets.BayesNet{BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64}}}({3, 3} directed simple Int64 graph, BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64}}[2 instantiations:\n",
+       "BayesNets.BayesNet{BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64,Vector{Float64}}}}({3, 3} directed simple Int64 graph, BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64,Vector{Float64}}}[2 instantiations:\n",
        "  a (2), 4 instantiations:\n",
        "  b (2)\n",
        "  a (2), 12 instantiations:\n",
@@ -1036,7 +1036,7 @@
        "\n"
       ],
       "text/plain": [
-       "BayesNets.BayesNet{BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64}}}({3, 2} directed simple Int64 graph, BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64}}[2 instantiations:\n",
+       "BayesNets.BayesNet{BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64,Vector{Float64}}}}({3, 2} directed simple Int64 graph, BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64,Vector{Float64}}}[2 instantiations:\n",
        "  a (2), 2 instantiations:\n",
        "  b (2), 8 instantiations:\n",
        "  c (2)\n",
@@ -1530,7 +1530,7 @@
        "\n"
       ],
       "text/plain": [
-       "BayesNets.BayesNet{BayesNets.CPDs.CPD}({5, 7} directed simple Int64 graph, BayesNets.CPDs.CPD[BayesNets.CPDs.StaticCPD{Distributions.Categorical{Float64}}(:Species, Symbol[], Distributions.Categorical{Float64}(K=3, p=[0.333333, 0.333333, 0.333333])), BayesNets.CPDs.ConditionalLinearGaussianCPD(:PetalLength, Symbol[:Species], Symbol[:Species], [3], BayesNets.CPDs.LinearGaussianCPD[BayesNets.CPDs.LinearGaussianCPD(:PetalLength, Symbol[], Float64[], 1.462, 0.173664), BayesNets.CPDs.LinearGaussianCPD(:PetalLength, Symbol[], Float64[], 4.26, 0.469911), BayesNets.CPDs.LinearGaussianCPD(:PetalLength, Symbol[], Float64[], 5.552, 0.551895)]), BayesNets.CPDs.ConditionalLinearGaussianCPD(:SepalLength, Symbol[:Species, :PetalLength], Symbol[:Species], [3], BayesNets.CPDs.LinearGaussianCPD[BayesNets.CPDs.LinearGaussianCPD(:SepalLength, Symbol[:PetalLength], [0.542293], 4.21317, 0.35249), BayesNets.CPDs.LinearGaussianCPD(:SepalLength, Symbol[:PetalLength], [0.828281], 2.40752, 0.516171), BayesNets.CPDs.LinearGaussianCPD(:SepalLength, Symbol[:PetalLength], [0.995739], 1.05966, 0.63588)]), BayesNets.CPDs.ConditionalLinearGaussianCPD(:SepalWidth, Symbol[:Species, :SepalLength], Symbol[:Species], [3], BayesNets.CPDs.LinearGaussianCPD[BayesNets.CPDs.LinearGaussianCPD(:SepalWidth, Symbol[:SepalLength], [0.798528], -0.569433, 0.379064), BayesNets.CPDs.LinearGaussianCPD(:SepalWidth, Symbol[:SepalLength], [0.319719], 0.872146, 0.313798), BayesNets.CPDs.LinearGaussianCPD(:SepalWidth, Symbol[:SepalLength], [0.23189], 1.44631, 0.322497)]), BayesNets.CPDs.ConditionalLinearGaussianCPD(:PetalWidth, Symbol[:Species, :PetalLength], Symbol[:Species], [3], BayesNets.CPDs.LinearGaussianCPD[BayesNets.CPDs.LinearGaussianCPD(:PetalWidth, Symbol[:PetalLength], [0.201245], -0.0482203, 0.105386), BayesNets.CPDs.LinearGaussianCPD(:PetalWidth, Symbol[:PetalLength], [0.331054], -0.0842884, 0.197753), BayesNets.CPDs.LinearGaussianCPD(:PetalWidth, Symbol[:PetalLength], [0.160297], 1.13603, 0.27465)])], Dict(:SepalLength=>3,:SepalWidth=>4,:PetalWidth=>5,:PetalLength=>2,:Species=>1))"
+       "BayesNets.BayesNet{BayesNets.CPDs.CPD}({5, 7} directed simple Int64 graph, BayesNets.CPDs.CPD[BayesNets.CPDs.StaticCPD{Distributions.Categorical{Float64,Vector{Float64}}}(:Species, Symbol[], Distributions.Categorical{Float64,Vector{Float64}}(K=3, p=[0.333333, 0.333333, 0.333333])), BayesNets.CPDs.ConditionalLinearGaussianCPD(:PetalLength, Symbol[:Species], Symbol[:Species], [3], BayesNets.CPDs.LinearGaussianCPD[BayesNets.CPDs.LinearGaussianCPD(:PetalLength, Symbol[], Float64[], 1.462, 0.173664), BayesNets.CPDs.LinearGaussianCPD(:PetalLength, Symbol[], Float64[], 4.26, 0.469911), BayesNets.CPDs.LinearGaussianCPD(:PetalLength, Symbol[], Float64[], 5.552, 0.551895)]), BayesNets.CPDs.ConditionalLinearGaussianCPD(:SepalLength, Symbol[:Species, :PetalLength], Symbol[:Species], [3], BayesNets.CPDs.LinearGaussianCPD[BayesNets.CPDs.LinearGaussianCPD(:SepalLength, Symbol[:PetalLength], [0.542293], 4.21317, 0.35249), BayesNets.CPDs.LinearGaussianCPD(:SepalLength, Symbol[:PetalLength], [0.828281], 2.40752, 0.516171), BayesNets.CPDs.LinearGaussianCPD(:SepalLength, Symbol[:PetalLength], [0.995739], 1.05966, 0.63588)]), BayesNets.CPDs.ConditionalLinearGaussianCPD(:SepalWidth, Symbol[:Species, :SepalLength], Symbol[:Species], [3], BayesNets.CPDs.LinearGaussianCPD[BayesNets.CPDs.LinearGaussianCPD(:SepalWidth, Symbol[:SepalLength], [0.798528], -0.569433, 0.379064), BayesNets.CPDs.LinearGaussianCPD(:SepalWidth, Symbol[:SepalLength], [0.319719], 0.872146, 0.313798), BayesNets.CPDs.LinearGaussianCPD(:SepalWidth, Symbol[:SepalLength], [0.23189], 1.44631, 0.322497)]), BayesNets.CPDs.ConditionalLinearGaussianCPD(:PetalWidth, Symbol[:Species, :PetalLength], Symbol[:Species], [3], BayesNets.CPDs.LinearGaussianCPD[BayesNets.CPDs.LinearGaussianCPD(:PetalWidth, Symbol[:PetalLength], [0.201245], -0.0482203, 0.105386), BayesNets.CPDs.LinearGaussianCPD(:PetalWidth, Symbol[:PetalLength], [0.331054], -0.0842884, 0.197753), BayesNets.CPDs.LinearGaussianCPD(:PetalWidth, Symbol[:PetalLength], [0.160297], 1.13603, 0.27465)])], Dict(:SepalLength=>3,:SepalWidth=>4,:PetalWidth=>5,:PetalLength=>2,:Species=>1))"
       ]
      },
      "execution_count": 27,
@@ -1604,7 +1604,7 @@
        "\n"
       ],
       "text/plain": [
-       "BayesNets.BayesNet{BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64}}}({3, 3} directed simple Int64 graph, BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64}}[2 instantiations:\n",
+       "BayesNets.BayesNet{BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64,Vector{Float64}}}}({3, 3} directed simple Int64 graph, BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64,Vector{Float64}}}[2 instantiations:\n",
        "  a (2), 4 instantiations:\n",
        "  b (2)\n",
        "  a (2), 12 instantiations:\n",
@@ -1680,7 +1680,7 @@
        "\n"
       ],
       "text/plain": [
-       "BayesNets.BayesNet{BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64}}}({3, 3} directed simple Int64 graph, BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64}}[2 instantiations:\n",
+       "BayesNets.BayesNet{BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64,Vector{Float64}}}}({3, 3} directed simple Int64 graph, BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64,Vector{Float64}}}[2 instantiations:\n",
        "  a (2), 6 instantiations:\n",
        "  b (3)\n",
        "  a (2), 18 instantiations:\n",
@@ -1925,7 +1925,7 @@
        "\n"
       ],
       "text/plain": [
-       "BayesNets.BayesNet{BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64}}}({2, 1} directed simple Int64 graph, BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64}}[2 instantiations:\n",
+       "BayesNets.BayesNet{BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64,Vector{Float64}}}}({2, 1} directed simple Int64 graph, BayesNets.CPDs.CategoricalCPD{Distributions.Categorical{Float64,Vector{Float64}}}[2 instantiations:\n",
        "  Success (2), 6 instantiations:\n",
        "  Forecast (3)\n",
        "  Success (2)], Dict(:Forecast=>2,:Success=>1))"

--- a/src/CPDs/categorical_cpd.jl
+++ b/src/CPDs/categorical_cpd.jl
@@ -102,7 +102,7 @@ end
 
 #####
 
-const DiscreteCPD = CategoricalCPD{Categorical{Float64}}
+const DiscreteCPD = CategoricalCPD{Categorical{Float64,Vector{Float64}}}
 
 DiscreteCPD(target::NodeName, prob::AbstractVector{T}) where {T<:Real} = CategoricalCPD(target, Categorical(prob ./ sum(prob)))
 
@@ -112,8 +112,8 @@ function Distributions.fit(::Type{DiscreteCPD},
     ncategories::Int = infer_number_of_instantiations(data[target]),
     )
 
-    d = convert(Categorical{Float64}, fit_mle(Categorical, ncategories, data[target]))
-    CategoricalCPD(target, NodeName[], Int[], Categorical{Float64}[d])
+    d = convert(Categorical{Float64,Vector{Float64}}, fit_mle(Categorical, ncategories, data[target]))
+    CategoricalCPD(target, NodeName[], Int[], Categorical{Float64,Vector{Float64}}[d])
 end
 function Distributions.fit(::Type{DiscreteCPD},
     data::DataFrame,
@@ -131,7 +131,7 @@ function Distributions.fit(::Type{DiscreteCPD},
 
     nparents = length(parents)
     dims = [1:parental_ncategories[i] for i in 1:nparents]
-    distributions = Array{Categorical{Float64}}(undef, prod(parental_ncategories))
+    distributions = Array{Categorical{Float64,Vector{Float64}}}(undef, prod(parental_ncategories))
     arr = Array{eltype(data[target])}(undef, 0)
     for (q, parent_instantiation) in enumerate(Iterators.product(dims...))
         empty!(arr)
@@ -143,7 +143,7 @@ function Distributions.fit(::Type{DiscreteCPD},
         if !isempty(arr)
             distributions[q] = fit_mle(Categorical, target_ncategories, arr)
         else
-            distributions[q] = Categorical{Float64}(target_ncategories)
+            distributions[q] = Categorical(target_ncategories)
         end
     end
 

--- a/src/DiscreteBayesNet/discrete_bayes_net.jl
+++ b/src/DiscreteBayesNet/discrete_bayes_net.jl
@@ -37,10 +37,10 @@ function rand_cpd(bn::DiscreteBayesNet, ncategories::Int, target::NodeName, pare
     parental_ncategories = _get_parental_ncategories(bn, parents)
 
     Q = prod(parental_ncategories)
-    distributions = Array{Categorical{Float64}}(undef, Q)
+    distributions = Array{Categorical{Float64,Vector{Float64}}}(undef, Q)
     dir = Dirichlet(ncategories, uniform_dirichlet_prior) # draw random categoricals from a Dirichlet distribution
     for q in 1:Q
-        distributions[q] = Categorical{Float64}(rand(dir))
+        distributions[q] = Categorical{Float64,Vector{Float64}}(rand(dir))
     end
 
     CategoricalCPD(target, parents, parental_ncategories, distributions)

--- a/src/DiscreteBayesNet/greedy_hill_climbing.jl
+++ b/src/DiscreteBayesNet/greedy_hill_climbing.jl
@@ -25,8 +25,8 @@ function Distributions.fit(::Type{DiscreteCPD},
         prior_counts[v] += 1.0
     end
 
-    d = Categorical{Float64}(prior_counts ./ sum(prior_counts))
-    CategoricalCPD(target, NodeName[], Int[], Categorical{Float64}[d])
+    d = Categorical{Float64,Vector{Float64}}(prior_counts ./ sum(prior_counts))
+    CategoricalCPD(target, NodeName[], Int[], Categorical{Float64,Vector{Float64}}[d])
 end
 function Distributions.fit(::Type{DiscreteCPD},
     data::DataFrame,
@@ -45,7 +45,7 @@ function Distributions.fit(::Type{DiscreteCPD},
 
     nparents = length(parents)
     dims = [1:parental_ncategories[i] for i in 1:nparents]
-    distributions = Array{Categorical{Float64}}(undef, prod(parental_ncategories))
+    distributions = Array{Categorical{Float64,Vector{Float64}}}(undef, prod(parental_ncategories))
     for (q, parent_instantiation) in enumerate(Iterators.product(dims...))
 
         prior_counts = get(prior, target_ncategories)
@@ -54,7 +54,7 @@ function Distributions.fit(::Type{DiscreteCPD},
                 prior_counts[data[i, target]] += 1.0
             end
         end
-        distributions[q] = Categorical{Float64}(prior_counts ./ sum(prior_counts))
+        distributions[q] = Categorical{Float64,Vector{Float64}}(prior_counts ./ sum(prior_counts))
     end
 
     CategoricalCPD(target, parents, parental_ncategories, distributions)

--- a/src/DiscreteBayesNet/io.jl
+++ b/src/DiscreteBayesNet/io.jl
@@ -72,7 +72,7 @@ function readxdsl( filename::AbstractString )
             for q in 1:Q
                 hi = k*q
                 lo = hi - k + 1
-                distributions[q] = Categorical{Float64}(probs[lo:hi])
+                distributions[q] = Categorical{Float64,Vector{Float64}}(probs[lo:hi])
             end
 
             push!(bn, DiscreteCPD(node_sym, parents, parental_ncategories, distributions))

--- a/src/DiscreteBayesNet/tables.jl
+++ b/src/DiscreteBayesNet/tables.jl
@@ -37,9 +37,9 @@ function Base.:*(t1::Table, t2::Table)
     finalnames = vcat(setdiff(union(names(f1), names(f2)), [:p]), :p)
 
     if isempty(onnames)
-        j = join(f1, f2, kind=:cross)
+        j = join(f1, f2, kind=:cross, makeunique=true)
     else
-        j = join(f1, f2, on=onnames, kind=:outer)
+        j = join(f1, f2, on=onnames, kind=:outer, makeunique=true)
     end
 
     j[:p] = broadcast(*, j[:p], j[:p_1])

--- a/src/Factors/factors_dims.jl
+++ b/src/Factors/factors_dims.jl
@@ -97,14 +97,14 @@ function reducedim!(op, ϕ::Factor, dims::NodeNameUnion, v0=nothing)
     return ϕ
 end
 
-Base.sum(ϕ::Factor, dims) = reducedim(+, ϕ, dims)
-Base.sum!(ϕ::Factor, dims) = reducedim!(+, ϕ, dims)
-Base.prod(ϕ::Factor, dims) = reducedim(*, ϕ, dims)
-Base.prod!(ϕ::Factor, dims) = reducedim!(*, ϕ, dims)
-Base.maximum(ϕ::Factor, dims) = reducedim(max, ϕ, dims)
-Base.maximum!(ϕ::Factor, dims) = reducedim!(max, ϕ, dims)
-Base.minimum(ϕ::Factor, dims) = reducedim(min, ϕ, dims)
-Base.minimum!(ϕ::Factor, dims) = reducedim!(min, ϕ, dims)
+Base.sum(ϕ::Factor, dims::NodeNameUnion) = reducedim(+, ϕ, dims)
+Base.sum!(ϕ::Factor, dims::NodeNameUnion) = reducedim!(+, ϕ, dims)
+Base.prod(ϕ::Factor, dims::NodeNameUnion) = reducedim(*, ϕ, dims)
+Base.prod!(ϕ::Factor, dims::NodeNameUnion) = reducedim!(*, ϕ, dims)
+Base.maximum(ϕ::Factor, dims::NodeNameUnion) = reducedim(max, ϕ, dims)
+Base.maximum!(ϕ::Factor, dims::NodeNameUnion) = reducedim!(max, ϕ, dims)
+Base.minimum(ϕ::Factor, dims::NodeNameUnion) = reducedim(min, ϕ, dims)
+Base.minimum!(ϕ::Factor, dims::NodeNameUnion) = reducedim!(min, ϕ, dims)
 
 """
     broadcast(f, ϕ, dims, values)

--- a/test/test_gibbs.jl
+++ b/test/test_gibbs.jl
@@ -100,7 +100,7 @@ let
         d_bn = DiscreteBayesNet()
         push!(d_bn, DiscreteCPD(:a, [1.0,0.0]))
         push!(d_bn, DiscreteCPD(:b, [0.0,1.0]))
-        push!(d_bn, CategoricalCPD{Categorical{Float64}}(:c, [:a, :b], [2,2], 
+        push!(d_bn, CategoricalCPD{Categorical{Float64,Vector{Float64}}}(:c, [:a, :b], [2,2], 
                         [Categorical([0.1, 0.9]), Categorical([0.2, 0.8]), Categorical([1.0, 0.0]), Categorical([0.4, 0.6])]))
 
 	t12 = gibbs_sample(d_bn, 5, 100; thinning=5, consistent_with=Assignment(),


### PR DESCRIPTION
Updates package and tests to reflect the following changes in dependencies:

- `join` of `DataFrames` needs `makeunique=true`

- `Categorical` needs to be given both `P` and `Ps <: AbstractVector{P}` as template arguments