### PR TITLE
DataFrames deprecation warning removal for Julia v1.1.1 -- fixes #75

### DIFF
--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -26,7 +26,10 @@ function Random.rand(bn::BayesNet, sampler::BayesNetSampler, nsamples::Integer)
     a = rand(bn, sampler)
     df = DataFrame()
     for cpd in bn.cpds
-        df[name(cpd)] = Array{typeof(a[name(cpd)])}(undef, nsamples)
+        begin
+            df[!, name(cpd)] = Array{typeof(a[name(cpd)])}(undef, nsamples)
+            df
+        end
     end
 
     for i in 1:nsamples

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -26,9 +26,7 @@ function Random.rand(bn::BayesNet, sampler::BayesNetSampler, nsamples::Integer)
     a = rand(bn, sampler)
     df = DataFrame()
     for cpd in bn.cpds
-        begin
-            df[!, name(cpd)] = Array{typeof(a[name(cpd)])}(undef, nsamples)
-        end
+        df[!, name(cpd)] = Array{typeof(a[name(cpd)])}(undef, nsamples)
     end
 
     for i in 1:nsamples

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -28,7 +28,6 @@ function Random.rand(bn::BayesNet, sampler::BayesNetSampler, nsamples::Integer)
     for cpd in bn.cpds
         begin
             df[!, name(cpd)] = Array{typeof(a[name(cpd)])}(undef, nsamples)
-            df
         end
     end
 


### PR DESCRIPTION
Fixed Julia v1.1 syntax deprecation warnings for setting all rows of a DataFrame.