### PR TITLE
More DataFrames deprecation warning fixes: d[cols] = X modified to d[!,cols] = X

### DIFF
--- a/src/DiscreteBayesNet/structure_scoring.jl
+++ b/src/DiscreteBayesNet/structure_scoring.jl
@@ -188,11 +188,11 @@ Note that every entry in data must be an integer greater than 0
 function bayesian_score(G::DAG,
                         names::Vector{Symbol},
                         data::DataFrame,
-                        ncategories::Vector{Int}=Int[infer_number_of_instantiations(convert(Vector{Int}, data[n])) for n in names],
+                        ncategories::Vector{Int}=Int[infer_number_of_instantiations(convert(Vector{Int}, data[!,n])) for n in names],
                         prior::DirichletPrior=UniformPrior())
     datamat = Array{Int}(undef, ncol(data), nrow(data))
     for i in 1:nv(G)
-        datamat[i,:] = data[names[i]]
+        datamat[i,:] = data[!,names[i]]
     end
 
     # NOTE: this is badj(G) prior to v0.6 and inneighbors(G) in v0.6


### PR DESCRIPTION
### Re-creation
The DataFrames deprecation warnings are produced from this example in the BayesNets.jl documentation: https://nbviewer.jupyter.org/github/sisl/BayesNets.jl/blob/master/doc/BayesNets.ipynb#Bayesian-Score-for-a-Network-Structure
```julia
using BayesNets

data = DataFrame(c=[1,1,1,1,2,2,2,2,3,3,3,3],
                 b=[1,1,1,2,2,2,2,1,1,2,1,1],
                 a=[1,1,1,2,1,1,2,1,1,2,1,1])
g = DAG(3)
add_edge!(g,1,2)
add_edge!(g,2,3)
add_edge!(g,1,3)
bayesian_score(g, [:a,:b,:c], data)
```

### Warnings
```julia
┌ Warning: `getindex(df::DataFrame, col_ind::ColumnIndex)` is deprecated, use `df[!, col_ind]` instead.             
│   caller = bayesian_score(::SimpleDiGraph{Int64}, ::Array{Symbol,1}, ::DataFrame) at structure_scoring.jl:193     
└ @ BayesNets C:\Users\RobertMoss\.julia\packages\BayesNets\S7a4X\src\DiscreteBayesNet\structure_scoring.jl:193     
┌ Warning: `getindex(df::DataFrame, col_ind::ColumnIndex)` is deprecated, use `df[!, col_ind]` instead.             
│   caller = bayesian_score(::SimpleDiGraph{Int64}, ::Array{Symbol,1}, ::DataFrame, ::Array{Int64,1}, ::UniformPrior) at structure_scoring.jl:195                                                                                       
└ @ BayesNets C:\Users\RobertMoss\.julia\packages\BayesNets\S7a4X\src\DiscreteBayesNet\structure_scoring.j
```

### Fix
Change how DataFrame columns are accessed:

**_Previous way (produces warnings, tested with Julia v1.1.1):_**
`df[cols]`

**_New way:_**
`df[!,cols]`