### PR TITLE
Replaced (deprecated?) warn function calls.

### DIFF
--- a/src/CPDs/utils.jl
+++ b/src/CPDs/utils.jl
@@ -61,7 +61,9 @@ Infer the number of instantiations, N, for a data type, assuming that it takes o
 function infer_number_of_instantiations(arr::AbstractVector{I}) where {I<:Int}
     lo, hi = extrema(arr)
     lo ≥ 1 || error("infer_number_of_instantiations assumes values in 1:N, value $lo found!")
-    lo == 1 || warn("infer_number_of_instantiations assumes values in 1:N, lowest value is $(lo)!")
+    if lo == 1
+        @warn "infer_number_of_instantiations assumes values in 1:N, lowest value is $(lo)!"
+    end
     hi
 end
 

--- a/src/Factors/factors_main.jl
+++ b/src/Factors/factors_main.jl
@@ -23,8 +23,9 @@ mutable struct Factor
             throw(DimensionMismatch("`potential` must have as many " *
                         "dimensions as dims"))
 
-        (:potential in dims) &&
-            warn("Having a dimension called `potential` will cause problems")
+        if :potential in dims
+            @warn "Having a dimension called `potential` will cause problems"
+        end
 
         return new(dims, potential)
     end

--- a/src/bayes_nets.jl
+++ b/src/bayes_nets.jl
@@ -292,7 +292,7 @@ the ith cpd will swap i and n and then remove n.
 function Base.delete!(bn::BayesNet, target::NodeName)
 
 	if outdegree(bn.dag, bn.name_to_index[target]) > 0
-		warn("Deleting a CPD with children!")
+		@warn "Deleting a CPD with children!"
 	end
 
 	i = bn.name_to_index[target]


### PR DESCRIPTION
I was getting errors cause the `warn` function doesn't exist so I replaced calls to this function with the `@warn` [logging](https://docs.julialang.org/en/v1/stdlib/Logging/) macro.