### PR TITLE
Updating GraphPlot

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BayesNets"
 uuid = "ba4760a4-c768-5bed-964b-cf806dc591cb"
-version = "3.4.0"
+version = "3.4.1"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -30,7 +30,7 @@ DataStructures = "0.11,0.12,0.13,0.14,0.15,0.16,0.17,0.18"
 Discretizers = "3.0"
 Distributions = "0.17,0.18,0.19,0.20,0.21,0.22,0.23,0.24, 0.25"
 Documenter = "0.26, 0.27"
-GraphPlot = "0.3,0.3.1,0.4,0.4.1"
+GraphPlot = "0.5"
 IterTools = "1.3"
 Graphs = "1.0"
 LightXML = "0.8,0.9"


### PR DESCRIPTION
GraphPlot v0.4 as currently used by BayesNets.jl does not support Graphs and instead uses LightGraphs. Hence updating it to v0.5.