### PR TITLE
Fix documentation plotting examples and doctest failures (Issue #157)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,5 @@
 name: CI
 
-# Run on master, tags, or any pull request
 on:
   push:
     branches: [master]
@@ -8,31 +7,35 @@ on:
   pull_request:
 
 jobs:
-  # unit tests with coverage
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+
+    # ============================
+    # 🔴 TEMPORARY DEBUG FLAG
+    # REMOVE THIS ENTIRE env BLOCK
+    # ============================
+    env:
+      SKIP_DEPS: "true"
+
     strategy:
       fail-fast: false
       matrix:
         version:
-          - "1"   # Latest
-          - "1.8" # Earliest
+          - "1"
         os:
           - ubuntu-latest
-          - windows-latest
-          - macos-latest
         arch:
           - x64
+
     steps:
-      # check out the project and install Julia
       - uses: actions/checkout@v4
+
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
 
-      # using a cache can speed up execution times
       - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
@@ -45,14 +48,25 @@ jobs:
             ${{ runner.os }}-${{ matrix.arch }}-
             ${{ runner.os }}-
 
-      # build the depencies, run the tests, and upload coverage results
-      - uses: julia-actions/julia-buildpkg@latest
+      # ============================
+      # Dependency build (skipped temporarily)
+      # ============================
+      - name: Build dependencies
+        if: env.SKIP_DEPS != 'true'
+        uses: julia-actions/julia-buildpkg@latest
+
       - run: |
           git config --global user.name Tester
           git config --global user.email te@st.er
+
+      # ============================
+      # Run tests (ALWAYS runs)
+      # ============================
       - name: Run Tests
         uses: julia-actions/julia-runtest@latest
+
       - uses: julia-actions/julia-processcoverage@v1
+
       - uses: codecov/codecov-action@v1
         with:
           file: ./lcov.info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,6 @@
 name: CI
 
+# Run on master, tags, or any pull request
 on:
   push:
     branches: [master]
@@ -7,35 +8,31 @@ on:
   pull_request:
 
 jobs:
+  # unit tests with coverage
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
-
-    # ============================
-    # 🔴 TEMPORARY DEBUG FLAG
-    # REMOVE THIS ENTIRE env BLOCK
-    # ============================
-    env:
-      SKIP_DEPS: "true"
-
     strategy:
       fail-fast: false
       matrix:
         version:
-          - "1"
+          - "1"   # Latest
+          - "1.8" # Earliest
         os:
           - ubuntu-latest
+          - windows-latest
+          - macos-latest
         arch:
           - x64
-
     steps:
+      # check out the project and install Julia
       - uses: actions/checkout@v4
-
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
 
+      # using a cache can speed up execution times
       - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
@@ -48,25 +45,14 @@ jobs:
             ${{ runner.os }}-${{ matrix.arch }}-
             ${{ runner.os }}-
 
-      # ============================
-      # Dependency build (skipped temporarily)
-      # ============================
-      - name: Build dependencies
-        if: env.SKIP_DEPS != 'true'
-        uses: julia-actions/julia-buildpkg@latest
-
+      # build the depencies, run the tests, and upload coverage results
+      - uses: julia-actions/julia-buildpkg@latest
       - run: |
           git config --global user.name Tester
           git config --global user.email te@st.er
-
-      # ============================
-      # Run tests (ALWAYS runs)
-      # ============================
       - name: Run Tests
         uses: julia-actions/julia-runtest@latest
-
       - uses: julia-actions/julia-processcoverage@v1
-
       - uses: codecov/codecov-action@v1
         with:
           file: ./lcov.info

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,6 +5,7 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
 TikzGraphs = "b4f28e30-c73f-5eaf-a395-8a9db949a742"
 TikzPictures = "37f6aa50-8035-52d0-81c2-5a1d08754b2d"
+Compose = "a81c6b42-2e10-5240-aca2-a61377ecd94b"
 
 [compat]
 Documenter = "1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,11 +1,14 @@
 [deps]
 BayesNets = "ba4760a4-c768-5bed-964b-cf806dc591cb"
+Compose = "a81c6b42-2e10-5240-aca2-a61377ecd94b"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Discretizers = "6e83dbb3-75ca-525b-8ae2-3751f0dd50b4"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 RDatasets = "ce6b1742-4840-55fa-b093-852dadbb1d8b"
 TikzGraphs = "b4f28e30-c73f-5eaf-a395-8a9db949a742"
 TikzPictures = "37f6aa50-8035-52d0-81c2-5a1d08754b2d"
-Compose = "a81c6b42-2e10-5240-aca2-a61377ecd94b"
 
 [compat]
 Documenter = "1"

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -5,8 +5,6 @@ CurrentModule = BayesNets
 
 ```@setup bayesnet
 using BayesNets
-using Compose
-import Compose: SVG
 using DataFrames
 using Distributions
 using Random
@@ -28,10 +26,10 @@ bn = BayesNet()
 push!(bn, StaticCPD(:a, Normal(1.0)))
 push!(bn, LinearGaussianCPD(:b, [:a], [2.0], 3.0, 1.0))
 p = BayesNets.plot(bn)
-draw(SVG(joinpath(@__DIR__, "plot1.svg"), 400, 400), p)
+p
 ```
 
-![](plot1.svg)
+
 
 ## Conditional Probability Distributions
 
@@ -59,10 +57,10 @@ cpdB = fit(LinearGaussianCPD, data, :b, [:a])
 
 bn2 = BayesNet([cpdA, cpdB])
 p = BayesNets.plot(bn2)
-draw(SVG(joinpath(@__DIR__, "plot2.svg"), 400, 400), p)
+p
 ```
 
-![](plot2.svg)
+
 
 Each `CPD` implements four functions:
 
@@ -91,20 +89,18 @@ bn2 = BayesNet()
 push!(bn2, StaticCPD(:sighted, NamedCategorical([:bird, :plane, :superman], [0.40, 0.55, 0.05])))
 push!(bn2, FunctionalCPD{Bernoulli}(:happy, [:sighted], a->Bernoulli(a == :superman ? 0.95 : 0.2)))
 p = BayesNets.plot(bn2)
-draw(SVG(joinpath(@__DIR__, "plot3.svg"), 400, 400), p)
+p
 ```
 
-![](plot3.svg)
+
 
 Variables can be removed by name using `delete!`. A warning will be issued when removing a CPD with children.
 
 ```@example bayesnet
 delete!(bn2, :happy)
 p = BayesNets.plot(bn2)
-draw(SVG(joinpath(@__DIR__, "plot4.svg"), 400, 400), p)
+p
 ```
-
-![](plot4.svg)
 
 ## Likelihood
 
@@ -156,10 +152,9 @@ push!(bn, StaticCPD(:a, Categorical([0.3,0.7])))
 push!(bn, StaticCPD(:b, Categorical([0.6,0.4])))
 push!(bn, CategoricalCPD{Bernoulli}(:c, [:a, :b], [2,2], [Bernoulli(0.1), Bernoulli(0.2), Bernoulli(1.0), Bernoulli(0.4)]))
 p = BayesNets.plot(bn)
-draw(SVG(joinpath(@__DIR__, "plot5.svg"), 400, 400), p)
+p
 ```
 
-![](plot5.svg)
 
 ```julia
 rand(bn, RejectionSampler(:c=>1), 5)
@@ -205,10 +200,10 @@ a=[1,1,1,2,1,1,2,1,1,2,1,1])
 
 bn5 = fit(DiscreteBayesNet, data, (:a=>:b, :a=>:c, :b=>:c))
 p = BayesNets.plot(bn5)
-draw(SVG(joinpath(@__DIR__, "plot6.svg"), 400, 400), p)
+p
 ```
 
-![](plot6.svg)
+
 
 Fitting a ```DiscreteCPD```, which is a ```CategoricalCPD{Categorical}```, can be done with a specified number of categories. This prevents cases where your test data does not provide an example for every category.
 
@@ -233,10 +228,10 @@ push!(bn, DiscreteCPD(:c, [:a, :b], [2,2],
         ]))
 
 p = BayesNets.plot(bn)
-draw(SVG(joinpath(@__DIR__, "plot7.svg"), 400, 400), p)
+p
 ```
 
-![](plot7.svg)
+
 
 ```@example bayesnet
 ϕ = infer(bn, :c, evidence=Assignment(:b=>1))
@@ -291,10 +286,10 @@ parameters = K2GraphSearch([:Species, :SepalLength, :SepalWidth, :PetalLength, :
 bn = fit(BayesNet, data, parameters)
 
 p = BayesNets.plot(bn)
-draw(SVG(joinpath(@__DIR__, "plot8.svg"), 400, 400), p)
+p
 ```
 
-![](plot8.svg)
+
 
 CPD types can also be specified per-node. Note that complete CPD definitions are required - simply using `StaticCPD` is insufficient as you need the target distribution type as well, as in `StaticCPD{Categorical}`.
 
@@ -320,10 +315,10 @@ parameters = GreedyHillClimbing(ScoreComponentCache(data), max_n_parents=3, prio
 bn = fit(DiscreteBayesNet, data, parameters)
 
 p = BayesNets.plot(bn)
-draw(SVG(joinpath(@__DIR__, "plot9.svg"), 400, 400), p)
+p
 ```
 
-![](plot9.svg)
+
 
 We can specify the number of categories for each variable in case it cannot be correctly inferred:
 
@@ -347,10 +342,10 @@ count(bn, :a, data)
 statistics(bn.dag, data)
 ```
 ```@example bayesnet
-table(bn, :b)
+BayesNets.table(bn, :b)
 ```
 ```@example bayesnet
-table(bn, :c, :a=>1)
+BayesNets.table(bn, :c, :a=>1)
 ```
 
 ## Reading from XDSL
@@ -361,10 +356,10 @@ Discrete Bayesian Networks can be read from the .XDSL file format.
 bn = readxdsl(joinpath(dirname(pathof(BayesNets)), "..", "test", "sample_bn.xdsl"))
 
 p = BayesNets.plot(bn)
-draw(SVG(joinpath(@__DIR__, "plot10.svg"), 400, 400), p)
+p
 ```
 
-![](plot10.svg)
+
 
 ## Bayesian Score for a Network Structure
 

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -1,14 +1,16 @@
+```@meta
+CurrentModule = BayesNets
+```
 # Usage
 
 ```@setup bayesnet
 using BayesNets
 using Compose
-```
-
-```julia
+import Compose: SVG
+using DataFrames
+using Distributions
 using Random
-using BayesNets
-using Compose
+using Graphs
 Random.seed!(0)
 ```
 
@@ -26,7 +28,7 @@ bn = BayesNet()
 push!(bn, StaticCPD(:a, Normal(1.0)))
 push!(bn, LinearGaussianCPD(:b, [:a], [2.0], 3.0, 1.0))
 p = BayesNets.plot(bn)
-draw(SVG("plot1.svg", 400, 400), p)
+draw(SVG(joinpath(@__DIR__, "plot1.svg"), 400, 400), p)
 ```
 
 ![](plot1.svg)
@@ -57,7 +59,7 @@ cpdB = fit(LinearGaussianCPD, data, :b, [:a])
 
 bn2 = BayesNet([cpdA, cpdB])
 p = BayesNets.plot(bn2)
-draw(SVG("plot2.svg", 400, 400), p)
+draw(SVG(joinpath(@__DIR__, "plot2.svg"), 400, 400), p)
 ```
 
 ![](plot2.svg)
@@ -66,7 +68,7 @@ Each `CPD` implements four functions:
 
 * `name(cpd)` - obtain the name of the variable target variable
 * `parents(cpd)` - obtain the list of parents
-* `nparams(cpd` - obtain the number of free parameters in the CPD
+* `nparams(cpd)` - obtain the number of free parameters in the CPD
 * `cpd(assignment)` - allows calling `cpd()` to obtain the conditional distribution
 * `Distributions.fit(Type{CPD}, data, target, parents)`
 
@@ -89,7 +91,7 @@ bn2 = BayesNet()
 push!(bn2, StaticCPD(:sighted, NamedCategorical([:bird, :plane, :superman], [0.40, 0.55, 0.05])))
 push!(bn2, FunctionalCPD{Bernoulli}(:happy, [:sighted], a->Bernoulli(a == :superman ? 0.95 : 0.2)))
 p = BayesNets.plot(bn2)
-draw(SVG("plot3.svg", 400, 400), p)
+draw(SVG(joinpath(@__DIR__, "plot3.svg"), 400, 400), p)
 ```
 
 ![](plot3.svg)
@@ -99,7 +101,7 @@ Variables can be removed by name using `delete!`. A warning will be issued when 
 ```@example bayesnet
 delete!(bn2, :happy)
 p = BayesNets.plot(bn2)
-draw(SVG("plot4.svg", 400, 400), p)
+draw(SVG(joinpath(@__DIR__, "plot4.svg"), 400, 400), p)
 ```
 
 ![](plot4.svg)
@@ -154,7 +156,7 @@ push!(bn, StaticCPD(:a, Categorical([0.3,0.7])))
 push!(bn, StaticCPD(:b, Categorical([0.6,0.4])))
 push!(bn, CategoricalCPD{Bernoulli}(:c, [:a, :b], [2,2], [Bernoulli(0.1), Bernoulli(0.2), Bernoulli(1.0), Bernoulli(0.4)]))
 p = BayesNets.plot(bn)
-draw(SVG("plot5.svg", 400, 400), p)
+draw(SVG(joinpath(@__DIR__, "plot5.svg"), 400, 400), p)
 ```
 
 ![](plot5.svg)
@@ -203,7 +205,7 @@ a=[1,1,1,2,1,1,2,1,1,2,1,1])
 
 bn5 = fit(DiscreteBayesNet, data, (:a=>:b, :a=>:c, :b=>:c))
 p = BayesNets.plot(bn5)
-draw(SVG("plot6.svg", 400, 400), p)
+draw(SVG(joinpath(@__DIR__, "plot6.svg"), 400, 400), p)
 ```
 
 ![](plot6.svg)
@@ -231,7 +233,7 @@ push!(bn, DiscreteCPD(:c, [:a, :b], [2,2],
         ]))
 
 p = BayesNets.plot(bn)
-draw(SVG("plot7.svg", 400, 400), p)
+draw(SVG(joinpath(@__DIR__, "plot7.svg"), 400, 400), p)
 ```
 
 ![](plot7.svg)
@@ -289,7 +291,7 @@ parameters = K2GraphSearch([:Species, :SepalLength, :SepalWidth, :PetalLength, :
 bn = fit(BayesNet, data, parameters)
 
 p = BayesNets.plot(bn)
-draw(SVG("plot8.svg", 400, 400), p)
+draw(SVG(joinpath(@__DIR__, "plot8.svg"), 400, 400), p)
 ```
 
 ![](plot8.svg)
@@ -318,7 +320,7 @@ parameters = GreedyHillClimbing(ScoreComponentCache(data), max_n_parents=3, prio
 bn = fit(DiscreteBayesNet, data, parameters)
 
 p = BayesNets.plot(bn)
-draw(SVG("plot9.svg", 400, 400), p)
+draw(SVG(joinpath(@__DIR__, "plot9.svg"), 400, 400), p)
 ```
 
 ![](plot9.svg)
@@ -359,7 +361,7 @@ Discrete Bayesian Networks can be read from the .XDSL file format.
 bn = readxdsl(joinpath(dirname(pathof(BayesNets)), "..", "test", "sample_bn.xdsl"))
 
 p = BayesNets.plot(bn)
-draw(SVG("plot10.svg", 400, 400), p)
+draw(SVG(joinpath(@__DIR__, "plot10.svg"), 400, 400), p)
 ```
 
 ![](plot10.svg)
@@ -374,5 +376,5 @@ data = DataFrame(c=[1,1,1,1,2,2,2,2,3,3,3,3],
                  a=[1,1,1,2,1,1,2,1,1,2,1,1])
 g = DAG(3)
 add_edge!(g,1,2); add_edge!(g,2,3); add_edge!(g,1,3)
-bayesian_score(g, [:a,:b,:c], data)
+BayesNets.bayesian_score(g, [:a, :b, :c], data)
 ```

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -1,15 +1,15 @@
 # Usage
 
 ```@setup bayesnet
-using BayesNets, TikzGraphs, TikzPictures
+using BayesNets
+using Compose
 ```
 
 ```julia
 using Random
-Random.seed!(0) # seed the random number generator to 0, for a reproducible demonstration
 using BayesNets
-using TikzGraphs # required to plot tex-formatted graphs (recommended), otherwise GraphPlot.jl is used
-using TikzPictures
+using Compose
+Random.seed!(0)
 ```
 
 ## Representation
@@ -25,8 +25,8 @@ a = \mathcal{N}(0,1) \qquad b = \mathcal{N}(2a +3,1)
 bn = BayesNet()
 push!(bn, StaticCPD(:a, Normal(1.0)))
 push!(bn, LinearGaussianCPD(:b, [:a], [2.0], 3.0, 1.0))
-plot = BayesNets.plot(bn)
-TikzPictures.save(SVG("plot1"), plot)
+p = BayesNets.plot(bn)
+draw(SVG("plot1.svg", 400px, 400px), p)
 ```
 
 ![](plot1.svg)
@@ -56,8 +56,8 @@ cpdA = fit(StaticCPD{Normal}, data, :a)
 cpdB = fit(LinearGaussianCPD, data, :b, [:a])
 
 bn2 = BayesNet([cpdA, cpdB])
-plot = BayesNets.plot(bn2) # hide
-TikzPictures.save(SVG("plot2"), plot) # hide
+p = BayesNets.plot(bn2)
+draw(SVG("plot2.svg", 400px, 400px), p)
 ```
 
 ![](plot2.svg)
@@ -88,8 +88,8 @@ The NamedCategorical distribution allows for String or Symbol return values. The
 bn2 = BayesNet()
 push!(bn2, StaticCPD(:sighted, NamedCategorical([:bird, :plane, :superman], [0.40, 0.55, 0.05])))
 push!(bn2, FunctionalCPD{Bernoulli}(:happy, [:sighted], a->Bernoulli(a == :superman ? 0.95 : 0.2)))
-plot = BayesNets.plot(bn2) # hide
-TikzPictures.save(SVG("plot3"), plot) # hide
+p = BayesNets.plot(bn2)
+draw(SVG("plot3.svg", 400px, 400px), p)
 ```
 
 ![](plot3.svg)
@@ -98,8 +98,8 @@ Variables can be removed by name using `delete!`. A warning will be issued when 
 
 ```@example bayesnet
 delete!(bn2, :happy)
-plot = BayesNets.plot(bn2) # hide
-TikzPictures.save(SVG("plot4"), plot) # hide
+p = BayesNets.plot(bn2)
+draw(SVG("plot4.svg", 400px, 400px), p)
 ```
 
 ![](plot4.svg)
@@ -153,8 +153,8 @@ bn = BayesNet()
 push!(bn, StaticCPD(:a, Categorical([0.3,0.7])))
 push!(bn, StaticCPD(:b, Categorical([0.6,0.4])))
 push!(bn, CategoricalCPD{Bernoulli}(:c, [:a, :b], [2,2], [Bernoulli(0.1), Bernoulli(0.2), Bernoulli(1.0), Bernoulli(0.4)]))
-plot = BayesNets.plot(bn) # hide
-TikzPictures.save(SVG("plot5"), plot) # hide
+p = BayesNets.plot(bn)
+draw(SVG("plot5.svg", 400px, 400px), p)
 ```
 
 ![](plot5.svg)
@@ -202,8 +202,8 @@ b=[1,1,1,2,2,2,2,1,1,2,1,1],
 a=[1,1,1,2,1,1,2,1,1,2,1,1])
 
 bn5 = fit(DiscreteBayesNet, data, (:a=>:b, :a=>:c, :b=>:c))
-plot = BayesNets.plot(bn5) # hide
-TikzPictures.save(SVG("plot6"), plot) # hide
+p = BayesNets.plot(bn5)
+draw(SVG("plot6.svg", 400px, 400px), p)
 ```
 
 ![](plot6.svg)
@@ -230,8 +230,8 @@ push!(bn, DiscreteCPD(:c, [:a, :b], [2,2],
          Categorical([0.4,0.6]),
         ]))
 
-plot = BayesNets.plot(bn) # hide
-TikzPictures.save(SVG("plot7"), plot) # hide
+p = BayesNets.plot(bn)
+draw(SVG("plot7.svg", 400px, 400px), p)
 ```
 
 ![](plot7.svg)
@@ -288,8 +288,8 @@ parameters = K2GraphSearch([:Species, :SepalLength, :SepalWidth, :PetalLength, :
                        max_n_parents=2)
 bn = fit(BayesNet, data, parameters)
 
-plot = BayesNets.plot(bn) # hide
-TikzPictures.save(SVG("plot8"), plot) # hide
+p = BayesNets.plot(bn)
+draw(SVG("plot8.svg", 400px, 400px), p)
 ```
 
 ![](plot8.svg)
@@ -317,8 +317,8 @@ data = DataFrame(c=[1,1,1,1,2,2,2,2,3,3,3,3],
 parameters = GreedyHillClimbing(ScoreComponentCache(data), max_n_parents=3, prior=UniformPrior())
 bn = fit(DiscreteBayesNet, data, parameters)
 
-plot = BayesNets.plot(bn) # hide
-TikzPictures.save(SVG("plot9"), plot) # hide
+p = BayesNets.plot(bn)
+draw(SVG("plot9.svg", 400px, 400px), p)
 ```
 
 ![](plot9.svg)
@@ -358,8 +358,8 @@ Discrete Bayesian Networks can be read from the .XDSL file format.
 ```@example bayesnet
 bn = readxdsl(joinpath(dirname(pathof(BayesNets)), "..", "test", "sample_bn.xdsl"))
 
-plot = BayesNets.plot(bn) # hide
-TikzPictures.save(SVG("plot10"), plot) # hide
+p = BayesNets.plot(bn)
+draw(SVG("plot10.svg", 400px, 400px), p)
 ```
 
 ![](plot10.svg)

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -26,7 +26,7 @@ bn = BayesNet()
 push!(bn, StaticCPD(:a, Normal(1.0)))
 push!(bn, LinearGaussianCPD(:b, [:a], [2.0], 3.0, 1.0))
 p = BayesNets.plot(bn)
-draw(SVG("plot1.svg", 400px, 400px), p)
+draw(SVG("plot1.svg", 400, 400), p)
 ```
 
 ![](plot1.svg)
@@ -57,7 +57,7 @@ cpdB = fit(LinearGaussianCPD, data, :b, [:a])
 
 bn2 = BayesNet([cpdA, cpdB])
 p = BayesNets.plot(bn2)
-draw(SVG("plot2.svg", 400px, 400px), p)
+draw(SVG("plot2.svg", 400, 400), p)
 ```
 
 ![](plot2.svg)
@@ -89,7 +89,7 @@ bn2 = BayesNet()
 push!(bn2, StaticCPD(:sighted, NamedCategorical([:bird, :plane, :superman], [0.40, 0.55, 0.05])))
 push!(bn2, FunctionalCPD{Bernoulli}(:happy, [:sighted], a->Bernoulli(a == :superman ? 0.95 : 0.2)))
 p = BayesNets.plot(bn2)
-draw(SVG("plot3.svg", 400px, 400px), p)
+draw(SVG("plot3.svg", 400, 400), p)
 ```
 
 ![](plot3.svg)
@@ -99,7 +99,7 @@ Variables can be removed by name using `delete!`. A warning will be issued when 
 ```@example bayesnet
 delete!(bn2, :happy)
 p = BayesNets.plot(bn2)
-draw(SVG("plot4.svg", 400px, 400px), p)
+draw(SVG("plot4.svg", 400, 400), p)
 ```
 
 ![](plot4.svg)
@@ -154,7 +154,7 @@ push!(bn, StaticCPD(:a, Categorical([0.3,0.7])))
 push!(bn, StaticCPD(:b, Categorical([0.6,0.4])))
 push!(bn, CategoricalCPD{Bernoulli}(:c, [:a, :b], [2,2], [Bernoulli(0.1), Bernoulli(0.2), Bernoulli(1.0), Bernoulli(0.4)]))
 p = BayesNets.plot(bn)
-draw(SVG("plot5.svg", 400px, 400px), p)
+draw(SVG("plot5.svg", 400, 400), p)
 ```
 
 ![](plot5.svg)
@@ -203,7 +203,7 @@ a=[1,1,1,2,1,1,2,1,1,2,1,1])
 
 bn5 = fit(DiscreteBayesNet, data, (:a=>:b, :a=>:c, :b=>:c))
 p = BayesNets.plot(bn5)
-draw(SVG("plot6.svg", 400px, 400px), p)
+draw(SVG("plot6.svg", 400, 400), p)
 ```
 
 ![](plot6.svg)
@@ -231,7 +231,7 @@ push!(bn, DiscreteCPD(:c, [:a, :b], [2,2],
         ]))
 
 p = BayesNets.plot(bn)
-draw(SVG("plot7.svg", 400px, 400px), p)
+draw(SVG("plot7.svg", 400, 400), p)
 ```
 
 ![](plot7.svg)
@@ -289,7 +289,7 @@ parameters = K2GraphSearch([:Species, :SepalLength, :SepalWidth, :PetalLength, :
 bn = fit(BayesNet, data, parameters)
 
 p = BayesNets.plot(bn)
-draw(SVG("plot8.svg", 400px, 400px), p)
+draw(SVG("plot8.svg", 400, 400), p)
 ```
 
 ![](plot8.svg)
@@ -318,7 +318,7 @@ parameters = GreedyHillClimbing(ScoreComponentCache(data), max_n_parents=3, prio
 bn = fit(DiscreteBayesNet, data, parameters)
 
 p = BayesNets.plot(bn)
-draw(SVG("plot9.svg", 400px, 400px), p)
+draw(SVG("plot9.svg", 400, 400), p)
 ```
 
 ![](plot9.svg)
@@ -359,7 +359,7 @@ Discrete Bayesian Networks can be read from the .XDSL file format.
 bn = readxdsl(joinpath(dirname(pathof(BayesNets)), "..", "test", "sample_bn.xdsl"))
 
 p = BayesNets.plot(bn)
-draw(SVG("plot10.svg", 400px, 400px), p)
+draw(SVG("plot10.svg", 400, 400), p)
 ```
 
 ![](plot10.svg)


### PR DESCRIPTION
The documentation examples were failing due to outdated assumptions about the plotting backend (TikzPictures). This PR updates the examples to reflect the current BayesNets.plot behavior (returning a Compose.Context), allowing Documenter to render plots correctly. 